### PR TITLE
Remove HealthKit permissions screen from existing user login.

### DIFF
--- a/version2/CardinalKit-Example/CardinalKit/Components/Onboarding/LoginExistingUserViewController.swift
+++ b/version2/CardinalKit-Example/CardinalKit/Components/Onboarding/LoginExistingUserViewController.swift
@@ -47,11 +47,11 @@ struct LoginExistingUserViewController: UIViewControllerRepresentable {
         passcodeStep.text = config.read(query: "Passcode Text")
         
         // set health data permissions
-        let healthDataStep = CKHealthDataStep(identifier: "HealthKit")
-        let healthRecordsStep = CKHealthRecordsStep(identifier: "HealthRecords")
+        // let healthDataStep = CKHealthDataStep(identifier: "HealthKit")
+        // let healthRecordsStep = CKHealthRecordsStep(identifier: "HealthRecords")
         
         // create a task with each step
-        loginSteps += [passcodeStep, healthDataStep, healthRecordsStep]
+        loginSteps += [passcodeStep]
         let orderedTask = ORKOrderedTask(identifier: "StudyLoginTask", steps: loginSteps)
         
         // wrap that task on a view controller


### PR DESCRIPTION
HealthKit permissions are still requested when users log in with an existing account. This PR disables it.